### PR TITLE
Better exceptions

### DIFF
--- a/test/test_query.py
+++ b/test/test_query.py
@@ -9,7 +9,7 @@ standard_library.install_aliases()
 from builtins import *
 import unittest
 from whois import whois
-
+from whois.exceptions import DomainNotFoundError, WhoisServerNotFoundError
 
 class TestQuery(unittest.TestCase):
     def test_simple_ascii_domain(self):
@@ -23,6 +23,17 @@ class TestQuery(unittest.TestCase):
     def test_unicode_domain_and_tld(self):
         domain = 'россия.рф'
         whois(domain)
+
+    def test_tld_missing_domain(self):
+        domain = "improbablylongandunlikelytoactuallyberegistereddomain.com"
+        with self.assertRaises(DomainNotFoundError):
+            whois(domain)
+
+    @unittest.skip("need a better way to legitimately trigger this condition")
+    def test_tld_missing_whois_server(self):
+        domain = "nothinghere.blanco"
+        with self.assertRaises(WhoisServerNotFoundError):
+            whois(domain)
 
     def test_ipv4(self):
         """ Verify ipv4 addresses. """

--- a/whois/exceptions.py
+++ b/whois/exceptions.py
@@ -1,0 +1,16 @@
+class PywhoisError(Exception):
+    """
+    base exception
+    """
+
+
+class WhoisServerNotFoundError(PywhoisError):
+    """
+    Apparently some TLDs don't offer whois servers
+    """
+
+
+class DomainNotFoundError(PywhoisError):
+    """
+    Domain doesn't exist
+    """

--- a/whois/parser.py
+++ b/whois/parser.py
@@ -19,6 +19,8 @@ from past.builtins import basestring
 from builtins import str
 from builtins import *
 
+from .exceptions import PywhoisError, DomainNotFoundError, WhoisServerNotFoundError
+
 standard_library.install_aliases()
 
 try:
@@ -72,10 +74,6 @@ KNOWN_FORMATS = [
     'before %b-%Y',             # before aug-1996
     '%Y-%m-%d %H:%M:%S (%Z%z)'  # 2017-09-26 11:38:29 (GMT+00:00)
 ]
-
-
-class PywhoisError(Exception):
-    pass
 
 
 def datetime_parse(s):
@@ -135,7 +133,7 @@ class WhoisEntry(dict):
 
     def __init__(self, domain, text, regex=None):
         if 'This TLD has no whois server, but you can access the whois database at' in text:
-            raise PywhoisError(text)
+            raise WhoisServerNotFoundError(text)
         else:
             self.domain = domain
             self.text = text
@@ -391,7 +389,7 @@ class WhoisCl(WhoisEntry):
 
     def __init__(self, domain, text):
         if 'No match for "' in text:
-            raise PywhoisError(text)
+            raise DomainNotFoundError(text)
         else:
             WhoisEntry.__init__(self, domain, text, self.regex)
 
@@ -411,7 +409,7 @@ class WhoisSG(WhoisEntry):
     def __init__(self, domain, text):
 
         if 'Domain Not Found' in text:
-            raise PywhoisError(text)
+            raise DomainNotFoundError(text)
         else:
             WhoisEntry.__init__(self, domain, text, self.regex)
 
@@ -442,7 +440,7 @@ class WhoisPe(WhoisEntry):
 
     def __init__(self, domain, text):
         if 'No match for "' in text:
-            raise PywhoisError(text)
+            raise DomainNotFoundError(text)
         else:
             WhoisEntry.__init__(self, domain, text, self.regex)
 
@@ -453,7 +451,7 @@ class WhoisSpace(WhoisEntry):
 
     def __init__(self, domain, text):
         if 'No match for "' in text:
-            raise PywhoisError(text)
+            raise DomainNotFoundError(text)
         else:
             WhoisEntry.__init__(self, domain, text)
 
@@ -464,7 +462,7 @@ class WhoisCom(WhoisEntry):
 
     def __init__(self, domain, text):
         if 'No match for "' in text:
-            raise PywhoisError(text)
+            raise DomainNotFoundError(text)
         else:
             WhoisEntry.__init__(self, domain, text)
 
@@ -475,7 +473,7 @@ class WhoisNet(WhoisEntry):
 
     def __init__(self, domain, text):
         if 'No match for "' in text:
-            raise PywhoisError(text)
+            raise DomainNotFoundError(text)
         else:
             WhoisEntry.__init__(self, domain, text)
 
@@ -498,7 +496,7 @@ class WhoisOrg(WhoisEntry):
 
     def __init__(self, domain, text):
         if text.strip().startswith('NOT FOUND'):
-            raise PywhoisError(text)
+            raise DomainNotFoundError(text)
         else:
             WhoisEntry.__init__(self, domain, text)
 
@@ -522,7 +520,7 @@ class WhoisRo(WhoisEntry):
 
     def __init__(self, domain, text):
         if text.strip() == 'NOT FOUND':
-            raise PywhoisError(text)
+            raise DomainNotFoundError(text)
         else:
             WhoisEntry.__init__(self, domain, text, self.regex)
 
@@ -544,7 +542,7 @@ class WhoisRu(WhoisEntry):
 
     def __init__(self, domain, text):
         if 'No entries found' in text:
-            raise PywhoisError(text)
+            raise DomainNotFoundError(text)
         else:
             WhoisEntry.__init__(self, domain, text, self.regex)
 
@@ -569,7 +567,7 @@ class WhoisNl(WhoisEntry):
 
     def __init__(self, domain, text):
         if text.endswith('is free'):
-            raise PywhoisError(text)
+            raise DomainNotFoundError(text)
         else:
             WhoisEntry.__init__(self, domain, text, self.regex)
 
@@ -595,7 +593,7 @@ class WhoisLt(WhoisEntry):
 
     def __init__(self, domain, text):
         if text.endswith('available'):
-            raise PywhoisError(text)
+            raise DomainNotFoundError(text)
         else:
             WhoisEntry.__init__(self, domain, text, self.regex)
 
@@ -630,7 +628,7 @@ class WhoisName(WhoisEntry):
 
     def __init__(self, domain, text):
         if 'No match for ' in text:
-            raise PywhoisError(text)
+            raise DomainNotFoundError(text)
         else:
             WhoisEntry.__init__(self, domain, text, self.regex)
 
@@ -702,7 +700,7 @@ class WhoisUs(WhoisEntry):
 
     def __init__(self, domain, text):
         if 'Not found:' in text:
-            raise PywhoisError(text)
+            raise DomainNotFoundError(text)
         else:
             WhoisEntry.__init__(self, domain, text, self.regex)
 
@@ -724,7 +722,7 @@ class WhoisPl(WhoisEntry):
 
     def __init__(self, domain, text):
         if 'No information available about domain name' in text:
-            raise PywhoisError(text)
+            raise DomainNotFoundError(text)
         else:
             WhoisEntry.__init__(self, domain, text, self.regex)
 
@@ -747,7 +745,7 @@ class WhoisGroup(WhoisEntry):
 
     def __init__(self, domain, text):
         if 'Domain not found' in text:
-            raise PywhoisError(text)
+            raise DomainNotFoundError(text)
         else:
             WhoisEntry.__init__(self, domain, text, self.regex)
 
@@ -775,7 +773,7 @@ class WhoisCa(WhoisEntry):
 
     def __init__(self, domain, text):
         if 'Domain status:         available' in text or 'Not found:' in text:
-            raise PywhoisError(text)
+            raise DomainNotFoundError(text)
         else:
             WhoisEntry.__init__(self, domain, text, self.regex)
 
@@ -841,7 +839,7 @@ class WhoisMe(WhoisEntry):
 
     def __init__(self, domain, text):
         if 'NOT FOUND' in text:
-            raise PywhoisError(text)
+            raise DomainNotFoundError(text)
         else:
             WhoisEntry.__init__(self, domain, text, self.regex)
 
@@ -872,7 +870,7 @@ class WhoisUk(WhoisEntry):
 
     def __init__(self, domain, text):
         if 'No match for ' in text:
-            raise PywhoisError(text)
+            raise DomainNotFoundError(text)
         else:
             WhoisEntry.__init__(self, domain, text, self.regex)
 
@@ -893,7 +891,7 @@ class WhoisFr(WhoisEntry):
 
     def __init__(self, domain, text):
         if 'No entries found' in text:
-            raise PywhoisError(text)
+            raise DomainNotFoundError(text)
         else:
             WhoisEntry.__init__(self, domain, text, self.regex)
 
@@ -923,7 +921,7 @@ class WhoisFi(WhoisEntry):
 
     def __init__(self, domain, text):
         if 'Domain not ' in text:
-            raise PywhoisError(text)
+            raise DomainNotFoundError(text)
         else:
             WhoisEntry.__init__(self, domain, text, self.regex)
 
@@ -943,7 +941,7 @@ class WhoisJp(WhoisEntry):
 
     def __init__(self, domain, text):
         if 'No match!!' in text:
-            raise PywhoisError(text)
+            raise DomainNotFoundError(text)
         else:
             WhoisEntry.__init__(self, domain, text, self.regex)
 
@@ -963,7 +961,7 @@ class WhoisAU(WhoisEntry):
 
     def __init__(self, domain, text):
         if text.strip() == 'No Data Found':
-            raise PywhoisError(text)
+            raise DomainNotFoundError(text)
         else:
             WhoisEntry.__init__(self, domain, text, self.regex)
 
@@ -985,7 +983,7 @@ class WhoisEu(WhoisEntry):
 
     def __init__(self, domain, text):
         if text.strip() == 'Status: AVAILABLE':
-            raise PywhoisError(text)
+            raise DomainNotFoundError(text)
         else:
             WhoisEntry.__init__(self, domain, text, self.regex)
 
@@ -1011,7 +1009,7 @@ class WhoisEe(WhoisEntry):
 
     def __init__(self, domain, text):
         if text.strip() == 'Domain not found':
-            raise PywhoisError(text)
+            raise DomainNotFoundError(text)
         else:
             WhoisEntry.__init__(self, domain, text, self.regex)
 
@@ -1044,7 +1042,7 @@ class WhoisBr(WhoisEntry):
     def __init__(self, domain, text):
 
         if 'Not found:' in text:
-            raise PywhoisError(text)
+            raise DomainNotFoundError(text)
         else:
             WhoisEntry.__init__(self, domain, text, self.regex)
 
@@ -1080,7 +1078,7 @@ class WhoisKr(WhoisEntry):
 
     def __init__(self, domain, text):
         if text.endswith(' no match'):
-            raise PywhoisError(text)
+            raise DomainNotFoundError(text)
         else:
             WhoisEntry.__init__(self, domain, text, self.regex)
 
@@ -1110,7 +1108,7 @@ class WhoisPt(WhoisEntry):
 
     def __init__(self, domain, text):
         if text.strip() == 'No entries found':
-            raise PywhoisError(text)
+            raise DomainNotFoundError(text)
         else:
             WhoisEntry.__init__(self, domain, text, self.regex)
 
@@ -1127,7 +1125,7 @@ class WhoisBg(WhoisEntry):
 
     def __init__(self, domain, text):
         if 'does not exist in database!' in text:
-            raise PywhoisError(text)
+            raise DomainNotFoundError(text)
         else:
             WhoisEntry.__init__(self, domain, text, self.regex)
 
@@ -1154,7 +1152,7 @@ class WhoisDe(WhoisEntry):
 
     def __init__(self, domain, text):
         if 'Status: free' in text:
-            raise PywhoisError(text)
+            raise DomainNotFoundError(text)
         else:
             WhoisEntry.__init__(self, domain, text, self.regex)
 
@@ -1179,7 +1177,7 @@ class WhoisAt(WhoisEntry):
 
     def __init__(self, domain, text):
         if 'Status: free' in text:
-            raise PywhoisError(text)
+            raise DomainNotFoundError(text)
         else:
             WhoisEntry.__init__(self, domain, text, self.regex)
 
@@ -1197,7 +1195,7 @@ class WhoisBe(WhoisEntry):
 
     def __init__(self, domain, text):
         if 'Status: AVAILABLE' in text:
-            raise PywhoisError(text)
+            raise DomainNotFoundError(text)
         else:
             WhoisEntry.__init__(self, domain, text, self.regex)
 
@@ -1227,7 +1225,7 @@ class WhoisInfo(WhoisEntry):
 
     def __init__(self, domain, text):
         if text.strip() == 'NOT FOUND':
-            raise PywhoisError(text)
+            raise DomainNotFoundError(text)
         else:
             WhoisEntry.__init__(self, domain, text, self.regex)
 
@@ -1322,7 +1320,7 @@ class WhoisClub(WhoisEntry):
 
     def __init__(self, domain, text):
         if 'Not found:' in text:
-            raise PywhoisError(text)
+            raise DomainNotFoundError(text)
         else:
             WhoisEntry.__init__(self, domain, text, self.regex)
 
@@ -1348,7 +1346,7 @@ class WhoisIo(WhoisEntry):
 
     def __init__(self, domain, text):
         if 'is available for purchase' in text:
-            raise PywhoisError(text)
+            raise DomainNotFoundError(text)
         else:
             WhoisEntry.__init__(self, domain, text, self.regex)
 
@@ -1403,7 +1401,7 @@ class WhoisBiz(WhoisEntry):
 
     def __init__(self, domain, text):
         if 'No Data Found' in text:
-            raise PywhoisError(text)
+            raise DomainNotFoundError(text)
         else:
             WhoisEntry.__init__(self, domain, text, self.regex)
 
@@ -1469,7 +1467,7 @@ class WhoisMobi(WhoisEntry):
 
     def __init__(self, domain, text):
         if 'NOT FOUND' in text:
-            raise PywhoisError(text)
+            raise DomainNotFoundError(text)
         else:
             WhoisEntry.__init__(self, domain, text, self.regex)
 
@@ -1495,7 +1493,7 @@ class WhoisKg(WhoisEntry):
 
     def __init__(self, domain, text):
         if 'Data not found. This domain is available for registration' in text:
-            raise PywhoisError(text)
+            raise DomainNotFoundError(text)
         else:
             WhoisEntry.__init__(self, domain, text, self.regex)
 
@@ -1516,7 +1514,7 @@ class WhoisChLi(WhoisEntry):
 
     def __init__(self, domain, text):
         if 'We do not have an entry in our database matching your query.' in text:
-            raise PywhoisError(text)
+            raise DomainNotFoundError(text)
         else:
             WhoisEntry.__init__(self, domain, text, self.regex)
 
@@ -1559,7 +1557,7 @@ class WhoisID(WhoisEntry):
 
     def __init__(self, domain, text):
         if 'NOT FOUND' in text:
-            raise PywhoisError(text)
+            raise DomainNotFoundError(text)
         else:
             WhoisEntry.__init__(self, domain, text, self.regex)
 
@@ -1582,7 +1580,7 @@ class WhoisSe(WhoisEntry):
 
     def __init__(self, domain, text):
         if 'not found.' in text:
-            raise PywhoisError(text)
+            raise DomainNotFoundError(text)
         else:
             WhoisEntry.__init__(self, domain, text, self.regex)
 
@@ -1659,7 +1657,7 @@ class WhoisJobs(WhoisEntry):
 
     def __init__(self, domain, text):
         if 'not found.' in text:
-            raise PywhoisError(text)
+            raise DomainNotFoundError(text)
         else:
             WhoisEntry.__init__(self, domain, text, self.regex)
 
@@ -1693,7 +1691,7 @@ class WhoisIt(WhoisEntry):
 
     def __init__(self, domain, text):
         if 'not found.' in text:
-            raise PywhoisError(text)
+            raise DomainNotFoundError(text)
         else:
             WhoisEntry.__init__(self, domain, text, self.regex)
 
@@ -1719,7 +1717,7 @@ class WhoisSa(WhoisEntry):
 
     def __init__(self, domain, text):
         if 'not found.' in text:
-            raise PywhoisError(text)
+            raise DomainNotFoundError(text)
         else:
             WhoisEntry.__init__(self, domain, text, self.regex)
 
@@ -1758,7 +1756,7 @@ class WhoisSK(WhoisEntry):
 
     def __init__(self, domain, text):
         if 'not found.' in text:
-            raise PywhoisError(text)
+            raise DomainNotFoundError(text)
         else:
             WhoisEntry.__init__(self, domain, text, self.regex)
 
@@ -1801,7 +1799,7 @@ class WhoisMx(WhoisEntry):
 
     def __init__(self, domain, text):
         if 'not found.' in text:
-            raise PywhoisError(text)
+            raise DomainNotFoundError(text)
         else:
             WhoisEntry.__init__(self, domain, text, self.regex)
 
@@ -1842,7 +1840,7 @@ class WhoisTw(WhoisEntry):
 
     def __init__(self, domain, text):
         if 'not found.' in text:
-            raise PywhoisError(text)
+            raise DomainNotFoundError(text)
         else:
             WhoisEntry.__init__(self, domain, text, self.regex)
 
@@ -1881,7 +1879,7 @@ class WhoisTr(WhoisEntry):
 
     def __init__(self, domain, text):
         if 'not found.' in text:
-            raise PywhoisError(text)
+            raise DomainNotFoundError(text)
         else:
             WhoisEntry.__init__(self, domain, text, self.regex)
 
@@ -1903,7 +1901,7 @@ class WhoisIs(WhoisEntry):
 
     def __init__(self, domain, text):
         if 'No entries found' in text:
-            raise PywhoisError(text)
+            raise DomainNotFoundError(text)
         else:
             WhoisEntry.__init__(self, domain, text, self.regex)
 
@@ -1928,7 +1926,7 @@ class WhoisDk(WhoisEntry):
 
     def __init__(self, domain, text):
         if 'No match for ' in text:
-            raise PywhoisError(text)
+            raise DomainNotFoundError(text)
         else:
             WhoisEntry.__init__(self, domain, text, self.regex)
 
@@ -1993,7 +1991,7 @@ class WhoisAi(WhoisEntry):
 
     def __init__(self, domain, text):
         if 'not registered' in text:
-            raise PywhoisError(text)
+            raise DomainNotFoundError(text)
         else:
             WhoisEntry.__init__(self, domain, text, self.regex)
 
@@ -2018,7 +2016,7 @@ class WhoisIl(WhoisEntry):
 
     def __init__(self, domain, text):
         if 'No data was found' in text:
-            raise PywhoisError(text)
+            raise DomainNotFoundError(text)
         else:
             WhoisEntry.__init__(self, domain, text, self.regex)
 
@@ -2050,7 +2048,7 @@ class WhoisIn(WhoisEntry):
 
     def __init__(self, domain, text):
         if 'NOT FOUND' in text:
-            raise PywhoisError(text)
+            raise DomainNotFoundError(text)
         else:
             WhoisEntry.__init__(self, domain, text, self.regex)
 
@@ -2071,7 +2069,7 @@ class WhoisCat(WhoisEntry):
 
     def __init__(self, domain, text):
         if 'no matching objects' in text:
-            raise PywhoisError(text)
+            raise DomainNotFoundError(text)
         else:
             # Merge base class regex with specifics
             self._regex.copy().update(self.regex)
@@ -2096,7 +2094,7 @@ class WhoisIe(WhoisEntry):
 
     def __init__(self, domain, text):
         if 'no matching objects' in text:
-            raise PywhoisError(text)
+            raise DomainNotFoundError(text)
         else:
             WhoisEntry.__init__(self, domain, text, self.regex)
 
@@ -2122,7 +2120,7 @@ class WhoisNz(WhoisEntry):
 
     def __init__(self, domain, text):
         if 'no matching objects' in text:
-            raise PywhoisError(text)
+            raise DomainNotFoundError(text)
         else:
             WhoisEntry.__init__(self, domain, text, self.regex)
 
@@ -2157,7 +2155,7 @@ class WhoisLu(WhoisEntry):
 
     def __init__(self, domain, text):
         if 'No such domain' in text:
-            raise PywhoisError(text)
+            raise DomainNotFoundError(text)
         else:
             WhoisEntry.__init__(self, domain, text, self.regex)
 
@@ -2177,7 +2175,7 @@ class WhoisCz(WhoisEntry):
 
     def __init__(self, domain, text):
         if '% No entries found.' in text or 'Your connection limit exceeded' in text:
-            raise PywhoisError(text)
+            raise DomainNotFoundError(text)
         else:
             WhoisEntry.__init__(self, domain, text, self.regex)
 
@@ -2206,7 +2204,7 @@ class WhoisOnline(WhoisEntry):
 
     def __init__(self, domain, text):
         if 'Not found:' in text:
-            raise PywhoisError(text)
+            raise DomainNotFoundError(text)
         else:
             WhoisEntry.__init__(self, domain, text, self.regex)
 
@@ -2228,7 +2226,7 @@ class WhoisHr(WhoisEntry):
 
     def __init__(self, domain, text):
         if 'ERROR: No entries found' in text:
-            raise PywhoisError(text)
+            raise DomainNotFoundError(text)
         else:
             WhoisEntry.__init__(self, domain, text, self.regex)
 
@@ -2280,7 +2278,7 @@ class WhoisHk(WhoisEntry):
 
     def __init__(self, domain, text):
         if 'ERROR: No entries found' in text or 'The domain has not been registered' in text:
-            raise PywhoisError(text)
+            raise DomainNotFoundError(text)
         else:
             WhoisEntry.__init__(self, domain, text, self.regex)
 
@@ -2328,7 +2326,7 @@ class WhoisUA(WhoisEntry):
 
     def __init__(self, domain, text):
         if 'ERROR: No entries found' in text:
-            raise PywhoisError(text)
+            raise DomainNotFoundError(text)
         else:
             WhoisEntry.__init__(self, domain, text, self.regex)
 
@@ -2402,7 +2400,7 @@ class WhoisHn(WhoisEntry):
 
     def __init__(self, domain, text):
         if text.strip() == 'No matching record.':
-            raise PywhoisError(text)
+            raise DomainNotFoundError(text)
         else:
             WhoisEntry.__init__(self, domain, text, self.regex)
 
@@ -2466,7 +2464,7 @@ class WhoisLat(WhoisEntry):
 
     def __init__(self, domain, text):
         if text.strip() == 'No matching record.':
-            raise PywhoisError(text)
+            raise DomainNotFoundError(text)
         else:
             WhoisEntry.__init__(self, domain, text, self.regex)
 
@@ -2488,7 +2486,7 @@ class WhoisCn(WhoisEntry):
 
     def __init__(self, domain, text):
         if text.strip() == 'No matching record.':
-            raise PywhoisError(text)
+            raise DomainNotFoundError(text)
         else:
             WhoisEntry.__init__(self, domain, text, self.regex)
 
@@ -2520,7 +2518,7 @@ class WhoisApp(WhoisEntry):
 
     def __init__(self, domain, text):
         if text.strip() == 'Domain not found.':
-            raise PywhoisError(text)
+            raise DomainNotFoundError(text)
         else:
             WhoisEntry.__init__(self, domain, text, self.regex)
 
@@ -2552,7 +2550,7 @@ class WhoisMoney(WhoisEntry):
 
     def __init__(self, domain, text):
         if text.strip() == 'Domain not found.':
-            raise PywhoisError(text)
+            raise DomainNotFoundError(text)
         else:
             WhoisEntry.__init__(self, domain, text, self.regex)
 
@@ -2575,7 +2573,7 @@ class WhoisAr(WhoisEntry):
 
     def __init__(self, domain, text):
         if text.strip() == 'El dominio no se encuentra registrado en NIC Argentina':
-            raise PywhoisError(text)
+            raise DomainNotFoundError(text)
         else:
             WhoisEntry.__init__(self, domain, text, self.regex)
 
@@ -2600,7 +2598,7 @@ class WhoisBy(WhoisEntry):
 
     def __init__(self, domain, text):
         if text.strip() == 'El dominio no se encuentra registrado en NIC Argentina':
-            raise PywhoisError(text)
+            raise DomainNotFoundError(text)
         else:
             WhoisEntry.__init__(self, domain, text, self.regex)
 
@@ -2626,7 +2624,7 @@ class WhoisCr(WhoisEntry):
 
     def __init__(self, domain, text):
         if text.strip() == 'El dominio no existe.':
-            raise PywhoisError(text)
+            raise DomainNotFoundError(text)
         else:
             WhoisEntry.__init__(self, domain, text, self.regex)
 
@@ -2687,7 +2685,7 @@ class WhoisVe(WhoisEntry):
 
     def __init__(self, domain, text):
         if text.strip() == 'El dominio no existe.':
-            raise PywhoisError(text)
+            raise DomainNotFoundError(text)
         else:
             WhoisEntry.__init__(self, domain, text, self.regex)
 
@@ -2752,7 +2750,7 @@ class WhoisDo(WhoisEntry):
 
     def __init__(self, domain, text):
         if text.strip() == 'Extensión de dominio no válido.':
-            raise PywhoisError(text)
+            raise DomainNotFoundError(text)
         else:
             WhoisEntry.__init__(self, domain, text, self.regex)
 
@@ -2769,7 +2767,7 @@ class WhoisAe(WhoisEntry):
 
     def __init__(self, domain, text):
         if text.strip() == 'No Data Found':
-            raise PywhoisError(text)
+            raise DomainNotFoundError(text)
         else:
             WhoisEntry.__init__(self, domain, text, self.regex)
 
@@ -2788,7 +2786,7 @@ class WhoisSi(WhoisEntry):
 
     def __init__(self, domain, text):
         if 'No entries found for the selected source(s).' in text:
-            raise PywhoisError(text)
+            raise DomainNotFoundError(text)
         else:
             WhoisEntry.__init__(self, domain, text, self.regex)
 
@@ -2804,7 +2802,7 @@ class WhoisNo(WhoisEntry):
 
     def __init__(self, domain, text):
         if 'No match' in text:
-            raise PywhoisError(text)
+            raise DomainNotFoundError(text)
         else:
             WhoisEntry.__init__(self, domain, text, self.regex)
 
@@ -2826,7 +2824,7 @@ class WhoisKZ(WhoisEntry):
 
     def __init__(self, domain, text):
         if text.strip() == 'No entries found':
-            raise PywhoisError(text)
+            raise DomainNotFoundError(text)
         else:
             WhoisEntry.__init__(self, domain, text, self.regex)
             
@@ -2846,7 +2844,7 @@ class WhoisIR(WhoisEntry):
 
     def __init__(self, domain, text):
         if 'No match for "' in text:
-            raise PywhoisError(text)
+            raise DomainNotFoundError(text)
         else:
             WhoisEntry.__init__(self, domain, text, self.regex)
 
@@ -2866,7 +2864,7 @@ class WhoisZhongGuo(WhoisEntry):
 
     def __init__(self, domain, text):
         if 'No match for "' in text:
-            raise PywhoisError(text)
+            raise DomainNotFoundError(text)
         else:
             WhoisEntry.__init__(self, domain, text, self.regex)
             
@@ -2877,7 +2875,7 @@ class WhoisWebsite(WhoisEntry):
 
     def __init__(self, domain, text):
         if 'No match for "' in text:
-            raise PywhoisError(text)
+            raise DomainNotFoundError(text)
         else:
             WhoisEntry.__init__(self, domain, text)
 
@@ -2895,7 +2893,7 @@ class WhoisML(WhoisEntry):
 
     def __init__(self, domain, text):
         if 'Invalid query or domain name not known in the Point ML Domain Registry' in text:
-            raise PywhoisError(text)
+            raise DomainNotFoundError(text)
         else:
             WhoisEntry.__init__(self, domain, text, self.regex)
     
@@ -2915,7 +2913,7 @@ class WhoisOoo(WhoisEntry):
 
     def __init__(self, domain, text):
         if 'No entries found for the selected source(s).' in text:
-            raise PywhoisError(text)
+            raise DomainNotFoundError(text)
         else:
             WhoisEntry.__init__(self, domain, text, self.regex)
             
@@ -2926,7 +2924,7 @@ class WhoisMarket(WhoisEntry):
 
     def __init__(self, domain, text):
         if 'No entries found for the selected source(s).' in text:
-            raise PywhoisError(text)
+            raise DomainNotFoundError(text)
         else:
             WhoisEntry.__init__(self, domain, text, self.regex)
 
@@ -2999,6 +2997,6 @@ class WhoisZa(WhoisEntry):
 
     def __init__(self, domain, text):
         if text.startswith('Available'):
-            raise PywhoisError(text)
+            raise DomainNotFoundError(text)
         else:
             WhoisEntry.__init__(self, domain, text, self.regex)


### PR DESCRIPTION
Raises new more-specific exceptions for WHOIS server not found & domain not found instead of the generic `PywhoisError`. New exceptions are subclassed from original `PywhoisError` so existing except clauses in calling code should be unaffected

* adds: new `exceptions` module
  * move `PywhoisException` definition here
  * add new subclassed exceptions: `WhoisServerNotFoundError` and `DomainNotFoundError`
* adds: new tests (with 1 currently) skipped - mostly moot because upstream currently has quite a few pre-existing test issues